### PR TITLE
Also check $HISTFILE for custom histroy path

### DIFF
--- a/insert-all.ts
+++ b/insert-all.ts
@@ -17,7 +17,11 @@ const runDir = join(homeDir, "unknown")
 
 const databaseFile =
 	process.env.database || join(homeDir, ".histdb/zsh-history.db")
-const historyFile = process.env.history_file || join(homeDir, ".zsh_history")
+
+const historyFile =
+	process.env.history_file ||
+	process.env.HISTFILE ||
+	join(homeDir, ".zsh_history")
 
 type Entry = {
 	started: string


### PR DESCRIPTION
The program didn't work for me, because I had a custom path for `.zsh_history`. The program checks `$history_file` but I had it defined in `$HISTFILE`. So this pr adds a check for environment variable.